### PR TITLE
N plus 1 fixes

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -16,7 +16,7 @@ class CoursesController < ApplicationController
       @professor = Professor.find(params[:p])
     end
 
-    @all_reviews = @professor ? Review.where(:course_id => @course.id, :professor_id => @professor.id) : Review.where(:course_id => @course.id)
+    @all_reviews = @professor ? Review.where(:course_id => @course.id, :professor_id => @professor.id).includes(:votes) : Review.where(:course_id => @course.id).includes(:votes)
     @reviews_no_comments = @all_reviews.where(:comment => "")
     @reviews_with_comments = @all_reviews.where.not(:comment => "").sort_by{|r| - r.created_at.to_i}
     @reviews = @reviews_with_comments.paginate(:page => params[:page], :per_page=> 10)

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -45,7 +45,7 @@ class DepartmentsController < ApplicationController
     @count = @subdepartments.size
 
     # Fall 2015
-    @offered = offered(24)
+    @offered = Course.offered(24)
 
     respond_to do |format|
       format.html # show.html.erb
@@ -53,11 +53,7 @@ class DepartmentsController < ApplicationController
     end
   end
 
-  def offered(id)
-    sections = Section.where(:semester_id => id)
-    return Hash[sections.map{|section| [section.course_id, true]}]
-  end
-
+ 
   private
     def department_params
       params.require(:department).permit(:name)

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -44,12 +44,19 @@ class DepartmentsController < ApplicationController
 
     @count = @subdepartments.size
 
+    # Fall 2015
+    @offered = offered(24)
+
     respond_to do |format|
       format.html # show.html.erb
       format.json { render json: @department }
     end
   end
 
+  def offered(id)
+    sections = Section.where(:semester_id => id)
+    return Hash[sections.map{|section| [section.course_id, true]}]
+  end
 
   private
     def department_params

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -31,6 +31,12 @@ class Course < ActiveRecord::Base
     self.sections.select(:units).max.units.to_i
   end
 
+  def self.offered(id)
+    sections = Section.where(:semester_id => id)
+    return Hash[sections.map{|section| [section.course_id, true]}]
+  end
+
+
   def self.find_by_mnemonic_number(mnemonic, number)
     subdepartment = Subdepartment.includes(:courses).find_by(:mnemonic => mnemonic)
     if subdepartment

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -39,19 +39,4 @@ class Course < ActiveRecord::Base
       nil
     end
   end
-
-  def is_offered(year, season)
-    section = self.sections
-    if not section.nil?
-      self.sections.each do |section|
-        if not section.semester.nil?
-          if section.semester.year == year and section.semester.season == season
-            return true
-          end
-        end
-      end
-    end
-    return false
-  end
-
 end

--- a/app/views/departments/show.html.slim
+++ b/app/views/departments/show.html.slim
@@ -27,7 +27,7 @@ div#dept-list role="tabpanel"
                 br
                 - separator = (course.course_number / 1000) * 1000 + 1000
 
-              - if @offered[course.course_number]
+              - if @offered[course.id]
                 .bli data-no-turbolink=""= link_to "#{subdepartment.mnemonic} #{course.course_number}" + " " + course.title, course
               - else
                 li data-no-turbolink=""= link_to "#{subdepartment.mnemonic} #{course.course_number}" + " " + course.title, course

--- a/app/views/departments/show.html.slim
+++ b/app/views/departments/show.html.slim
@@ -27,7 +27,7 @@ div#dept-list role="tabpanel"
                 br
                 - separator = (course.course_number / 1000) * 1000 + 1000
 
-              - if course.is_offered(2014, "Fall")
+              - if @offered[course.course_number]
                 .bli data-no-turbolink=""= link_to "#{subdepartment.mnemonic} #{course.course_number}" + " " + course.title, course
               - else
                 li data-no-turbolink=""= link_to "#{subdepartment.mnemonic} #{course.course_number}" + " " + course.title, course

--- a/app/views/departments/show.html.slim
+++ b/app/views/departments/show.html.slim
@@ -26,7 +26,6 @@ div#dept-list role="tabpanel"
               - if course.course_number >= separator
                 br
                 - separator = (course.course_number / 1000) * 1000 + 1000
-
               - if @offered[course.id]
                 .bli data-no-turbolink=""= link_to "#{subdepartment.mnemonic} #{course.course_number}" + " " + course.title, course
               - else


### PR DESCRIPTION
Time for the entire page loading locally (with hard refresh) below. This is not just the SQL queries but should give a good idea of performance:

Timing for the Econ page with this change: 471 ms
Timing on beta: 8.99 s

Reviews fails to load locally without eager loading votes so was not able to compare. Page load takes ~1 second with change, though. 
@aw3as Want to give this a look sometime?