### PR TITLE
regex match non-spaces for search

### DIFF
--- a/app/controllers/scheduler_controller.rb
+++ b/app/controllers/scheduler_controller.rb
@@ -66,8 +66,8 @@ class SchedulerController < ApplicationController
       courses += Course.includes(:subdepartment).current.where('title LIKE ?', "%#{@query[0]}%")
       courses += Section.includes(:course => :subdepartment).where('topic LIKE ? AND semester_id = ?', "%#{@query[0]}%", 27).map(&:course).uniq
     else
-      courses += Course.includes(:subdepartment).where('title LIKE ?', "%#{@query[0]}%")
-      courses += Section.includes(:course => :subdepartment).where('topic LIKE ?', "%#{@query[0]}%").map(&:course).uniq
+      courses += Course.includes(:subdepartment).where('title LIKE ?', "%#{querystring}%")
+      courses += Section.includes(:course => :subdepartment).where('topic LIKE ?', "%#{querystring}%").map(&:course).uniq
     end
 
     render :json => {

--- a/app/controllers/scheduler_controller.rb
+++ b/app/controllers/scheduler_controller.rb
@@ -38,12 +38,12 @@ class SchedulerController < ApplicationController
   end
 
   def search
-	querystring = params[:query]
-	if !querystring.include? ' '
-    @query = querystring.strip.split(/(\d+)/)
-	else
-    @query = querystring.strip.split(' ')
-	end
+    querystring = params[:query]
+    if !querystring.include? ' '
+      @query = querystring.strip.split(/(\d+)/)
+    else
+      @query = querystring.strip.split(' ')
+    end
     courses = []
     params[:type] ||= 'current'
     if @query.length != 1 and !!/\A\d+\z/.match(@query[1])

--- a/app/controllers/scheduler_controller.rb
+++ b/app/controllers/scheduler_controller.rb
@@ -40,9 +40,9 @@ class SchedulerController < ApplicationController
   def search
 	querystring = params[:query]
 	if !querystring.include? ' '
-		@query = querystring.strip.split(/(\d+)/)
+    @query = querystring.strip.split(/(\d+)/)
 	else
-		@query = querystring.strip.split(' ')
+    @query = querystring.strip.split(' ')
 	end
     courses = []
     params[:type] ||= 'current'


### PR DESCRIPTION
When typing for class, does not ignore space (CS 4102 searches, but CS4102 did not). Fixed that so that CS4102 also matches.
