### PR TITLE
Fix markdown headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ Status:
 
 theCourseForum
 ==============
-###Connecting University of Virginia Students to Course information and Reviews
+### Connecting University of Virginia Students to Course information and Reviews
 
 
-###About
-theCourseForum was created by students for students. We gather freeley available information to help students evaluate their course options at the University. Students in turn then review courses in their own words for others to help others. 
+### About
+theCourseForum was created by students for students. We gather freeley available information to help students evaluate their course options at the University. Students in turn then review courses in their own words for others to help others.
 
-Started 5 years ago, the project has grown monuementally. A very large percentage of the student body uses the website each and every semester. We gather statists and other information in an effort to help students select classes better. The public code apart of this statement is the second major version of the website. 
+Started 5 years ago, the project has grown monuementally. A very large percentage of the student body uses the website each and every semester. We gather statists and other information in an effort to help students select classes better. The public code apart of this statement is the second major version of the website.
 
 The Organization itself is a group of students that contribute their time and effort to contiue to improve the site for other students to use.
 
-###Stack
-The code stack is current standard technologies. They were chosen specifically because they are standard, modern and incredibly ubiquitous technologies. 
+### Stack
+The code stack is current standard technologies. They were chosen specifically because they are standard, modern and incredibly ubiquitous technologies.
 
 - Ruby 2.2.3
 - Rails 4.2.4
@@ -22,11 +22,11 @@ The code stack is current standard technologies. They were chosen specifically b
 - Bootstrap 3
 - Javascript (jQuery)
 
-###Deployment
+### Deployment
 The rails app can be deployed in any fashion, there is no special deployment requirements. Our server deployment uses Phusion Passenger AKA mod_rails on top of the Apache Webserver. For development, we switch between Passenger testing and the thin development server. Internally, everything is vanilla including MySQL, Javascript, and Bootstrap 3.
 
-###Singular Deployment Guide
+### Singular Deployment Guide
 [Getting Started Guide](https://github.com/thecourseforum/theCourseForum/wiki/Environment-Setup-and-Deployment)
 
-###Want to get involved? 
+### Want to get involved?
 Don't hesitate to contact us whether or not that you are at the University of Virginia! We love to talk about our app and we love to discuss everything that we do! Shoot us an email at info@thecourseforum.com


### PR DESCRIPTION
Provides a quick fix for the markdown headings in our readme -- github must have changed the way it parses the markdown so I added extra spaces to correct it.