### PR TITLE
Removed broken blog link

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -22,16 +22,11 @@ nav.navbar.navbar-default.navbar-fixed-top#header-navbar
           a href="/textbooks" Check Here
         div overflow="auto"
           p Check out the faces behind tCF in the new About page.
-        div overflow="auto"
-          p Interested in the newest tCF redesign?
-          a target="_blank" href="http://blog.thecourseforum.com/thecourseforum-3-0/" Learn More
       ul.nav.navbar-nav.navbar-right.hidden-xs
         li
           a#report-bug FEEDBACK
         li
           a href="#{about_path}" ABOUT
-        li
-          a href="http://blog.thecourseforum.com" target="_blank" BLOG
         - if current_user
           li
             a#user-account data-toggle="dropdown" 


### PR DESCRIPTION
This removes the broken blog link. I don't think anyone is using/posting on the link and I tried a few different variations of the URL but can't figure out which is the right one. So for now I think we agreed we might as well remove it.