### PR TITLE
Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ lib/words.json
 
 # Ignore bundle
 /vendor/bundle
+
+# Ignore sql for calibration
+/sql/*.sql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,36 @@
-FROM ruby:2.2.3
+FROM ubuntu:latest
 
 RUN apt-get update
-RUN apt-get install -y git-core curl build-essential nodejs
 
+## Default Packages
+RUN apt-get install -y build-essential 
+RUN apt-get install -y wget curl git git-core apt-transport-https libmysqlclient-dev
+
+## RVM
+RUN \curl -sSL https://get.rvm.io | bash
+## Set path
+ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# setup rvm & ruby version
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.2.3"
+RUN /bin/bash -l -c "rvm use 2.2.3"
+RUN /bin/bash -l -c "gem install bundler -v 1.12.5"
+
+## Install gems
 RUN mkdir /tcf
 COPY . /tcf
 WORKDIR /tcf
-RUN gem install bundler -v 1.12.5
-RUN bundle install
+RUN /bin/bash -l -c "bundle install"
 
+## Setup mysql database
 RUN /bin/bash -l -c "debconf-set-selections <<< 'mysql-server mysql-server/root_password password data'"
 RUN /bin/bash -l -c "debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password data'"
 RUN apt-get -y install mysql-server
 RUN chmod 777 calibrate_db.sh
 RUN sed -i -e 's/\r$//' calibrate_db.sh
 
+## Rails app will listen on this port
 EXPOSE 3000
 
 CMD ["rails", "s"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.2.3
+
+RUN apt-get update
+RUN apt-get install -y git-core curl build-essential nodejs
+
+RUN mkdir /tcf
+COPY . /tcf
+WORKDIR /tcf
+RUN gem install bundler -v 1.12.5
+RUN bundle install
+
+RUN /bin/bash -l -c "debconf-set-selections <<< 'mysql-server mysql-server/root_password password data'"
+RUN /bin/bash -l -c "debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password data'"
+RUN apt-get -y install mysql-server
+RUN chmod 777 calibrate_db.sh
+RUN ./calibrate_db.sh
+
+EXPOSE 3000
+
+CMD ["rails", "s"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN /bin/bash -l -c "bundle install"
 RUN /bin/bash -l -c "debconf-set-selections <<< 'mysql-server mysql-server/root_password password data'"
 RUN /bin/bash -l -c "debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password data'"
 RUN apt-get -y install mysql-server
+RUN chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
 RUN chmod 777 calibrate_db.sh
 RUN sed -i -e 's/\r$//' calibrate_db.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN /bin/bash -l -c "debconf-set-selections <<< 'mysql-server mysql-server/root_
 RUN /bin/bash -l -c "debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password data'"
 RUN apt-get -y install mysql-server
 RUN chmod 777 calibrate_db.sh
-RUN ./calibrate_db.sh
+RUN sed -i -e 's/\r$//' calibrate_db.sh
 
 EXPOSE 3000
 

--- a/Gemfile
+++ b/Gemfile
@@ -114,3 +114,5 @@ gem "highcharts-rails", "~> 3.0.0"
 
 # for breadcrumbs
 gem 'breadcrumbs_on_rails'
+
+gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,8 @@ GEM
       multi_json (>= 1.3.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2018.9)
+      tzinfo (>= 1.0.0)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
@@ -361,6 +363,7 @@ DEPENDENCIES
   touchpunch-rails
   turbolinks
   twilio-ruby (~> 4.2.1)
+  tzinfo-data
   uglifier
   vacuum
   will_paginate (>= 3.0.3)
@@ -369,4 +372,4 @@ RUBY VERSION
    ruby 2.2.3p173
 
 BUNDLED WITH
-   1.12.5
+   1.17.3

--- a/calibrate_db.sh
+++ b/calibrate_db.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+mysql -u root -p <<QUERY 
+drop database if exists thecourseforum_development;drop database if exists thecourseforum_production;
+create database thecourseforum_development;
+create database thecourseforum_production;
+use thecourseforum_development;
+source ./sql/thecourseforum_development.sql
+use thecourseforum_production;
+source ./sql/thecourseforum_production.sql;
+QUERY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services: 
   tcf: 
     build: .
-    command: bash -c 'service mysql start && rails s -b 0.0.0.0'
+    command: bash -l -c 'service mysql start && bundle exec rails s -b 0.0.0.0'
     container_name: tcf
     volumes: 
       - .:/tcf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services: 
+  tcf: 
+    build: .
+    command: bash -c ' service mysql start && rails s -b 0.0.0.0'
+    container_name: tcf
+    volumes: 
+      - .:/tcf
+    tty: true
+    ports: 
+      - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services: 
   tcf: 
     build: .
-    command: bash -c ' service mysql start && rails s -b 0.0.0.0'
+    command: bash -c 'service mysql start && rails s -b 0.0.0.0'
     container_name: tcf
     volumes: 
       - .:/tcf

--- a/sql/setup.txt
+++ b/sql/setup.txt
@@ -11,7 +11,8 @@ SETTING UP DATABASE
 9. Export the thecourseforum_development and thecourseforum_production databases
 10. Place these .sql files within this sql/ directory
 11. docker-compose up
-12. The server will be listening on localhost:3000
+12. The server will be listening on localhost:3000 (Note: if you are using docker toolkit, you might have 
+	get the ip address of the docker vm using 'docker-machine ip' and replacing localhost with that address)
 13. To calibrate your database in the container, run the ./calibrate_db.sh script (to run the script, first enter the container's shell
 	    with 'docker exec -it tcf bash'. Then run the script.)
 14. When it prompts for your password, type in 'data'

--- a/sql/setup.txt
+++ b/sql/setup.txt
@@ -13,8 +13,8 @@ SETTING UP DATABASE
 11. docker-compose up
 12. The server will be listening on localhost:3000 (Note: if you are using docker toolkit, you might have 
 	get the ip address of the docker vm using 'docker-machine ip' and replacing localhost with that address)
-13. To calibrate your database in the container, run the ./calibrate_db.sh script (to run the script, first enter the container's shell
-	    with 'docker exec -it tcf bash'. Then run the script.)
+13. To calibrate your database in the container, run the ./calibrate_db.sh script (to run the script, first enter the 
+    container's shell with 'docker exec -it tcf bash'. Then run the script.)
 14. When it prompts for your password, type in 'data'
 15. The script will then update the db, this might take a few minutes...
 16. Once it finishes, you are ready to develop! :) 

--- a/sql/setup.txt
+++ b/sql/setup.txt
@@ -1,0 +1,19 @@
+SETTING UP DATABASE
+
+1. cp config/database.yml.skel config/database.yml
+2. Update passwords to 'data'
+3. cp config/initializers/devise.rb.example config/initializers/devise.rb
+4. touch config/initializers/secret_token.rb
+5. Add TheCourseForum::Application.config.secret_key_base = "othersecretkey1234"
+6. cp config/application.yml.example config/application.yml
+7. Login to http://phpmyadmin.thecourseforum.com/ (ask for username & password)
+8. Once you're logged in, expand thecourseforum tab on the left
+9. Export the thecourseforum_development and thecourseforum_production databases
+10. Place these .sql files within this sql/ directory
+11. docker-compose up
+12. The server will be listening on localhost:3000
+13. To calibrate your database in the container, run the ./calibrate_db.sh script (to run the script, first enter the container's shell
+	    with 'docker exec -it tcf bash'. Then run the script.)
+14. When it prompts for your password, type in 'data'
+15. The script will then update the db, this might take a few minutes...
+16. Once it finishes, you are ready to develop! :) 


### PR DESCRIPTION
1. Dockerfile that defines an ubuntu image with Ruby on Rails setup in accordance to our versions
2. Added a 'sql' directory with instructions to set up the container. Make sure to have thecourseforum_development.sql & thecourseforum_production.sql within that folder before you calibrate the database.
3. Added a calibration script that sets up the production and development databases

* Note: The mysql database is created within the container with a default password 'data.' Every time, you exit the container, the data will persist. If you do not want it to persist, then you can run 'docker-compose down' which will remove the images, services, and network defined within the docker-compose.yml. 

To test: 
Follow setup.txt and check if you can access localhost:3000 (and calibrate the db)

Tested on Ubuntu 18.04 & Windows 10