### PR TITLE
Split '/browse' API call into separate route

### DIFF
--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -6,6 +6,18 @@ class DepartmentsController < ApplicationController
       redirect_to root_url
       return
     end
+    
+    respond_to do |format|
+      format.html # index.html.erb
+    end
+  end
+
+  def list
+    if current_user == nil
+      redirect_to root_url
+      return
+    end
+
     subdepartments = Subdepartment.all
     departments = Department.all.order(:name)
     departments.uniq {|subdepartments| subdepartments.name}
@@ -13,17 +25,18 @@ class DepartmentsController < ApplicationController
     artSchoolId = 1
     engrSchoolId = 2
 
-    @artDeps = columnize(departments.select{|d| d.school_id == artSchoolId})
-    @engrDeps = columnize(departments.select{|d| d.school_id == engrSchoolId })
-    @otherSchools = columnize(departments.select{|d| d.school_id != artSchoolId && d.school_id != engrSchoolId })
+    artDeps = columnize(departments.select{|d| d.school_id == artSchoolId})
+    engrDeps = columnize(departments.select{|d| d.school_id == engrSchoolId })
+    otherSchools = columnize(departments.select{|d| d.school_id != artSchoolId && d.school_id != engrSchoolId })
 
-    @deps = {"Arts & Sciences": @artDeps, "Engineering & Applied Sciences": @engrDeps, "Other Schools at the University of Virginia": @otherSchools}
+    deps = {"Arts & Sciences": artDeps, "Engineering & Applied Sciences": engrDeps, "Other Schools at the University of Virginia": otherSchools}
 
     respond_to do |format|
-      format.html # index.html.erb
-      format.json { render json: @deps.as_json }
+      format.any { render json: deps.as_json, content_type: 'application/json' }
     end
+
   end
+
 
   # GET /departments/1
   def show

--- a/app/javascript/components/departments/Browse.js
+++ b/app/javascript/components/departments/Browse.js
@@ -19,7 +19,7 @@ class Browse extends React.Component {
   * Update state.
   */
   componentDidMount = () => {
-    fetch('/browse.json')
+    fetch('/api/departments/list')
       .then((response) => {
         return response.json();
       })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ TheCourseForum::Application.routes.draw do
   get '/scheduler/course' => 'scheduler#course'
   delete '/scheduler/courses' => 'scheduler#clear_courses'
 
+  ## API Routes
+  get '/api/departments/list' => 'departments#list'
+
 
   resources :bugs
 


### PR DESCRIPTION
Previously, React called '/browse.json' to get the JSON containing the
list of departments

Now, React calls '/api/departments/list' to get the JSON. I feel that
this is better practice and will allow us to modularize our code further
in the future.