### PR TITLE
action_mailer delivery debugging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ TheCourseForum::Application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found).


### PR DESCRIPTION
action_mailer "sends" confirmation emails, but they are not delivering. I configured action_mailer to raise delivery errors when they occur in an attempt to figure out why this bug is occurring.